### PR TITLE
some pool changes

### DIFF
--- a/include/hwmalloc/detail/pool.hpp
+++ b/include/hwmalloc/detail/pool.hpp
@@ -113,8 +113,11 @@ class pool
         block_type b;
         if (m_free_stack.pop(b)) return b;
         while (!m_mutex.try_lock())
-            if (m_free_stack.pop(b)) return b;
-        if (m_free_stack.pop(b)) return b;
+            if (m_free_stack.pop(b))
+            {
+                m_mutex.unlock();
+                return b;
+            }
         for (auto& kvp : m_segments) kvp.first->collect(m_free_stack);
         if (m_free_stack.pop(b))
         {


### PR DESCRIPTION
do not free the last segment, keep it for the future (address #18)
call unlock after mutex is locked and before return from function