### PR TITLE
Remove an allocation when using register_user_allocation

### DIFF
--- a/include/hwmalloc/detail/block.hpp
+++ b/include/hwmalloc/detail/block.hpp
@@ -19,9 +19,6 @@ template<typename Context>
 class segment;
 
 template<typename Context>
-struct user_allocation;
-
-template<typename Context>
 struct block_t
 {
     using region_traits_type = region_traits<Context>;
@@ -30,11 +27,11 @@ struct block_t
     using device_handle_type = typename region_traits_type::device_handle_type;
 #endif
     using segment_type = segment<Context>;
-    using user_allocation_type = user_allocation<Context>;
 
     segment_type*         m_segment = nullptr;
-    user_allocation_type* m_user_allocation = nullptr;
     void*                 m_ptr = nullptr;
+    void*                 m_user_ptr = nullptr;
+    bool                  m_user_delete = false;
     handle_type           m_handle;
 #if HWMALLOC_ENABLE_DEVICE
     void*              m_device_ptr = nullptr;
@@ -52,8 +49,7 @@ struct block_t
     void release() const noexcept
     {
         if (m_segment) release_from_segment();
-        else if (m_user_allocation)
-            release_user_allocation();
+        else release_user_allocation();
     }
 };
 

--- a/include/hwmalloc/detail/segment.hpp
+++ b/include/hwmalloc/detail/segment.hpp
@@ -84,7 +84,7 @@ class segment
         char* origin = (char*)m_allocation.m.ptr;
         for (std::size_t i = m_num_blocks; i > 0; --i)
         {
-            block b{this, nullptr, origin + (i - 1) * block_size,
+            block b{this, origin + (i - 1) * block_size, nullptr, false,
                 m_region.get_handle((i - 1) * block_size, block_size)};
             while (!free_stack.push(b)) {}
         }
@@ -109,7 +109,7 @@ class segment
         char* device_origin = (char*)m_device_allocation.m;
         for (std::size_t i = m_num_blocks; i > 0; --i)
         {
-            block b{this, nullptr, origin + (i - 1) * block_size,
+            block b{this, origin + (i - 1) * block_size, nullptr, false,
                 m_region.get_handle((i - 1) * block_size, block_size),
                 device_origin + (i - 1) * block_size,
                 m_device_region->get_handle((i - 1) * block_size, block_size), device_id};

--- a/include/hwmalloc/detail/user_allocation.hpp
+++ b/include/hwmalloc/detail/user_allocation.hpp
@@ -21,70 +21,42 @@ namespace detail
 template<typename Context>
 struct user_allocation
 {
-    using region_type = typename detail::region_traits<Context>::region_type;
+    using region_type = decltype(hwmalloc::register_memory(*((Context*)0), nullptr, 0u));
 #if HWMALLOC_ENABLE_DEVICE
     using device_region_type = typename detail::region_traits<Context>::device_region_type;
 #endif
     using block_type = block_t<Context>;
     using pointer = hw_void_ptr<block_type>;
 
-    struct host_allocation
-    {
-        void* m_ptr;
-        bool  m_delete;
-        host_allocation(void* ptr, bool del) noexcept
-        : m_ptr{ptr}
-        , m_delete{del}
-        {
-        }
-        host_allocation(host_allocation const&) noexcept = delete;
-        host_allocation& operator=(host_allocation const&) noexcept = delete;
-
-        host_allocation(host_allocation&& other) noexcept
-        : m_ptr{std::exchange(other.m_ptr, nullptr)}
-        , m_delete{other.m_delete}
-        {
-        }
-        host_allocation& operator=(host_allocation&& other) noexcept
-        {
-            if (m_ptr && m_delete) std::free(m_ptr);
-            m_ptr = std::exchange(other.m_ptr, nullptr);
-            m_delete = other.m_delete;
-            return *this;
-        }
-        ~host_allocation()
-        {
-            if (m_ptr && m_delete) std::free(m_ptr);
-        }
-    };
-
-    //Context*                     m_context;
-    host_allocation m_host_allocation;
+    void*           m_host_ptr;
+    bool            m_host_delete;
     region_type     m_region;
 #if HWMALLOC_ENABLE_DEVICE
     std::unique_ptr<device_region_type> m_device_region;
 #endif
 
     user_allocation(Context* context, void* ptr, std::size_t size)
-    //: m_context{context}
-    : m_host_allocation{ptr, false}
-    , m_region{hwmalloc::register_memory(*context, ptr, size)}
+        : m_host_ptr{ptr}
+        , m_host_delete{false}
+        , m_region{hwmalloc::register_memory(*context, ptr, size)}
     {
     }
 
 #if HWMALLOC_ENABLE_DEVICE
     user_allocation(Context* context, void* device_ptr, int /*device_id*/, std::size_t size)
-    : m_host_allocation{std::malloc(size), true}
-    , m_region{hwmalloc::register_memory(*context, m_host_allocation.m_ptr, size)}
-    , m_device_region{std::make_unique<device_region_type>(
+        : m_host_ptr{std::malloc(size)}
+        , m_host_delete{true}
+        , m_region{hwmalloc::register_memory(*context, m_host_ptr, size)}
+        , m_device_region{std::make_unique<device_region_type>(
           hwmalloc::register_device_memory(*context, device_ptr, size))}
     {
     }
 
     user_allocation(Context* context, void* ptr, void* device_ptr, int /*device_id*/, std::size_t size)
-    : m_host_allocation{ptr, false}
-    , m_region{hwmalloc::register_memory(*context, ptr, size)}
-    , m_device_region{std::make_unique<device_region_type>(
+        : m_host_ptr{ptr}
+        , m_host_delete{false}
+        , m_region{hwmalloc::register_memory(*context, ptr, size)}
+        , m_device_region{std::make_unique<device_region_type>(
           hwmalloc::register_device_memory(*context, device_ptr, size))}
     {
     }
@@ -95,7 +67,11 @@ template<typename Context>
 void
 block_t<Context>::release_user_allocation() const noexcept
 {
-    delete m_user_allocation;
+    // do we need to check m_user_ptr?
+    m_handle.deregister();
+    if (m_user_delete) {
+        std::free(m_user_ptr);
+    }
 }
 
 } // namespace detail

--- a/include/hwmalloc/heap.hpp
+++ b/include/hwmalloc/heap.hpp
@@ -213,8 +213,8 @@ class heap
 
     pointer register_user_allocation(void* ptr, std::size_t size)
     {
-        auto a = new detail::user_allocation<Context>{m_context, ptr, size};
-        return {block_type{nullptr, a, ptr, a->m_region.get_handle(0, size)}};
+        detail::user_allocation<Context> ua{m_context, ptr, size};
+        return {block_type{nullptr, ptr, ptr, false, std::move(ua.m_region)}};
     }
 
 #if HWMALLOC_ENABLE_DEVICE
@@ -241,16 +241,16 @@ class heap
 
     pointer register_user_allocation(void* device_ptr, int device_id, std::size_t size)
     {
-        auto a = new detail::user_allocation<Context>{m_context, device_ptr, device_id, size};
-        return {block_type{nullptr, a, a->m_host_allocation.m_ptr, a->m_region.get_handle(0, size),
-            device_ptr, a->m_device_region->get_handle(0, size), device_id}};
+        detail::user_allocation<Context> ua{m_context, device_ptr, device_id, size};
+        return {block_type{nullptr, device_ptr, ua.m_host_ptr, ua.m_host_delete, std::move(ua.m_region.get_handle(0, size)),
+            device_ptr, std::move(ua->m_device_region->get_handle(0, size)), device_id}};
     }
 
     pointer register_user_allocation(void* ptr, void* device_ptr, int device_id, std::size_t size)
     {
-        auto a = new detail::user_allocation<Context>{m_context, ptr, device_ptr, device_id, size};
-        return {block_type{nullptr, a, ptr, a->m_region.get_handle(0, size), device_ptr,
-            a->m_device_region->get_handle(0, size), device_id}};
+        detail::user_allocation<Context> ua{m_context, ptr, device_ptr, device_id, size};
+        return {block_type{nullptr, device_ptr, ua.m_host_ptr, ua.m_host_delete, std::move(ua->m_region.get_handle(0, size)),
+            device_ptr, std::move(ua->m_device_region->get_handle(0, size)), device_id}};
     }
 #endif
 


### PR DESCRIPTION
Move the contents of the user_allocation struct into the
main block and remove any dupllicated info. By storing the data
directly, we do not need a heap allocate a user struct.