### PR TITLE
Remove Clang-HIP workaround

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,8 +24,6 @@ if (HWMALLOC_ENABLE_DEVICE)
     elseif (${HWMALLOC_DEVICE_RUNTIME} STREQUAL "hip")
         find_package(hip REQUIRED)
         target_link_libraries(hwmalloc PRIVATE hip::device)
-        # workaround for clang-hip
-        target_compile_options(hwmalloc PRIVATE $<BUILD_INTERFACE:-std=c++14>)
     endif()
 
     target_sources(hwmalloc PRIVATE device_${HWMALLOC_DEVICE_RUNTIME}.cpp)


### PR DESCRIPTION
Setting `-std=c++14` breaks the build of the Python bindings for GHEX on LUMI using the latest software stack (LUMI/25.03).